### PR TITLE
FIX Don't use deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
           NEW_TAG=("v${MAJOR}.${MINOR}")
         fi
         echo "Tag is $NEW_TAG"
-        echo "::set-output name=tag::$NEW_TAG"
+        echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
     - name: Add tag to repo
       uses: silverstripe/gha-tag-release@v1


### PR DESCRIPTION
References:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

## Issue
- https://github.com/silverstripe/.github/issues/26