### PR TITLE
ENH Use v2 of the tag-release action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,8 +88,9 @@ runs:
         echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
     - name: Add tag to repo
-      uses: silverstripe/gha-tag-release@v1
+      uses: silverstripe/gha-tag-release@v2
       with:
+        skip_gauge_release: true
         tag: ${{ steps.generate_tag_name.outputs.new_tag }}
         delete_existing: true
         release: false


### PR DESCRIPTION
Updates to using the new major release of gha-tag-release

## Issue
- https://github.com/silverstripe/gha-ci/issues/137